### PR TITLE
Fix ansible-vault execution and update ansible version to 2.7.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.9
  
-ENV ANSIBLE_VERSION 2.7.6
+ENV ANSIBLE_VERSION 2.7.7
 
+ENV ANSIBLE_LOCAL_TEMP /tmp
 ENV ANSIBLE_HOST_KEY_CHECKING false
 ENV ANSIBLE_RETRY_FILES_ENABLED false
 ENV PYTHONPATH /ansible/lib
@@ -31,7 +32,7 @@ RUN set -ex && \
     apk update && apk upgrade && \
     apk add --no-cache ${BUILD_PACKAGES} && \
     pip install --upgrade pip && \
-    pip install PyYAML openshift ansible==${ANSIBLE_VERSION} && \
+    pip install pycrypto PyYAML openshift ansible==${ANSIBLE_VERSION} && \
     apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 NAME       = ansible-playbook
 NAMESPACE  = slopezz
-VERSION    = 2.7.6
+VERSION    = 2.7.7
 
 ANSIBLE_PLAYBOOK_EXECUTION ?= --version
 ANSIBLE_VAULT_EXECUTION    ?= --version
@@ -22,13 +22,13 @@ build: ## Build ansible-playbook image
 
 run: build ## Run ansible-playbook image
 	docker run --rm -it \
-	-v $(PROJECT_PATH):/ansible/playbooks \
+	-u $$(id -u):$$(id -g) -v /etc/passwd:/etc/passwd -v ~/:/home/$$(id -u -n) -v $(PROJECT_PATH):/ansible/playbooks \
 	$(IMAGE_NAME):$(VERSION) \
 	$(ANSIBLE_PLAYBOOK_EXECUTION)
 
 run-vault: build ## Run ansible-vault with ansible-playbook image
 	docker run --rm -it \
-	-v $(PROJECT_PATH):/ansible/playbooks \
+	-u $$(id -u):$$(id -g) -v /etc/passwd:/etc/passwd -v ~/:/home/$$(id -u -n) -v $(PROJECT_PATH):/ansible/playbooks \
 	--entrypoint ansible-vault \
 	$(IMAGE_NAME):$(VERSION) \
         $(ANSIBLE_VAULT_EXECUTION)

--- a/README.md
+++ b/README.md
@@ -8,27 +8,26 @@ It can be integrated into a CI/CD pipeline with all dependancies resolved.
 In addition, it has pip openshift package included, so it is possible to run ansible `k8s` module to run ansible playbooks with kubernetes or openshift clusters as targets.
 
 ```bash
-docker run --rm -it -v $(pwd):/ansible/playbooks slopezz/ansible-playbook site.yml
+docker run --rm -it -u $(id -u):$(id -g) -v /etc/passwd:/etc/passwd -v ~/:/home/$(id -u -n) -v $(pwd):/ansible/playbooks  slopezz/ansible-playbook site.yml
 ```
 
 You can add any possible ansible-playbook variable at the end of the execution, example:
 
 ```bash
-docker run --rm -it -v $(pwd):/ansible/playbooks slopezz/ansible-playbook -i inventory site.yml --tags any-role -CD --vault-password-file vault.secret
+docker run --rm -it -u $(id -u):$(id -g) -v /etc/passwd:/etc/passwd -v ~/:/home/$(id -u -n) -v $(pwd):/ansible/playbooks  slopezz/ansible-playbook -i inventory site.yml --tags any-role -CD --vault-password-file vault.secret
 ```
 
 ## ansible-vault
 
 If you want to run ansible-vault you can do it by changing the entrypoint:
 ```bash
-docker run --rm -it -v $(pwd):/ansible/playbooks --entrypoint ansible-vault slopezz/ansible-playbook edit host_vars/host_example/vault.yml --vault-password-file vault.secret
+docker run --rm -it -u $(id -u):$(id -g) -v /etc/passwd:/etc/passwd -v ~/:/home/$(id -u -n) -v $(pwd):/ansible/playbooks --entrypoint ansible-vault slopezz/ansible-playbook edit host_vars/host_example/vault.yml --vault-password-file vault.secret
 ```
 
-## Makefile
+## Usage
 
-With Makefile you can easily run some specific targets:
 ```bash
-$ make help
+$ make
 build                          Build ansible-playbook image
 run                            Run ansible-playbook image
 run-vault                      Run ansible-vault with ansible-playbook image
@@ -37,6 +36,6 @@ push                           Push ansible-playbook image
 help                           Print this help
 ```
 
-## Images
+## Docker images
 
-Docker images will be available with specific ansible versions on [docker Hub](https://hub.docker.com/r/slopezz/ansible-playbook/tags/)
+Docker images will be available with specific ansible versions on [docker Hub](https://cloud.docker.com/repository/docker/slopezz/ansible-playbook/tags)


### PR DESCRIPTION
- Update ansible version to 2.7.7
- Add pycrypto pip package in order to be able to use ansible-vault
- Add ENV VAR ANSIBLE_LOCAL_TEMP  with an unprivileged directory used for ansible tmp objects
- Update Makefile target executions to use current system user/group (so possible vault files will be created will have proper permissions)
- Improve README